### PR TITLE
Add league player distance & speed tracking

### DIFF
--- a/nba_py/constants.py
+++ b/nba_py/constants.py
@@ -413,6 +413,8 @@ class MeasureType:
     Usage = 'Usage'
     Default = Base
 
+class PtMeasureType:
+    SpeedDistance = 'SpeedDistance'
 
 class GroupQuantity:
     Default = 5

--- a/nba_py/league.py
+++ b/nba_py/league.py
@@ -185,6 +185,124 @@ class PlayerStats:
     def overall(self):
         return _api_scrape(self.json, 0)
 
+
+class _PlayerTrackingStats:
+    """
+    Args:
+        :league_id: ID for the league to look in (Default is 00)
+        :season_type: Season type to consider (Regular or Playoffs)
+        :player_or_team: Filter by (Player or Team)
+        :per_mode: Mode to measure statistics (Totals, PerGame, Per36, etc.)
+        :season: Season given to look up
+        :playoff_round: Playoff round
+        :outcome: Filter out by wins or losses
+        :location: Filter out by home or away
+        :month: Specify month to filter by
+        :season_segment: Filter by pre/post all star break
+        :date_from: Filter out games before a specific date
+        :date_to: Filter out games after a specific date
+        :opponent_team_id: Opponent team ID to look up
+        :vs_conference: Filter by conference
+        :vs_division: Filter by division
+        :team_id: ID of the team to look up
+        :conference: Filter by conference
+        :division: Filter by division
+        :last_n_games: Filter by number of games specified in N
+        :game_scope: Filter by GameScope (Yesterday, Last 10)
+        :player_experience: Player experience (Rookie, Sophomore, Veteran)
+        :player_position: Filter by position (Forward, Center, Guard)
+        :starter_bench: Filter by Starters or Bench
+        :draft_year: Filter by draft year
+        :draft_pick: Filter by draft pick (1st+Round, Lottery+Pick, etc.)
+        :college: Filter by college
+        :country: Filter by country
+        :height: Filter by player's height
+        :weight: Filter by player's weight
+
+    Attributes:
+        :json: Contains the full json dump to play around with
+    """
+    _endpoint = 'leaguedashptstats'
+    _pt_measure_type = ''
+
+    def __init__(self,
+                 league_id=League.Default,
+                 season_type=SeasonType.Default,
+                 player_or_team=PlayerOrTeam.Default,
+                 per_mode=PerMode.Default,
+                 season=CURRENT_SEASON,
+                 playoff_round=PlayoffRound.Default,
+                 outcome=Outcome.Default,
+                 location=Location.Default,
+                 month=Month.Default,
+                 season_segment=SeasonSegment.Default,
+                 date_from=DateFrom.Default,
+                 date_to=DateTo.Default,
+                 opponent_team_id=OpponentTeamID.Default,
+                 vs_conference=VsConference.Default,
+                 vs_division=VsDivision.Default,
+                 team_id=TeamID.Default,
+                 conference=Conference.Default,
+                 division=Division.Default,
+                 last_n_games=LastNGames.Default,
+                 game_scope=Game_Scope.Default,
+                 player_experience=PlayerExperience.Default,
+                 player_position=PlayerPosition.Default,
+                 starter_bench=StarterBench.Default,
+                 draft_year=DraftYear.Default,
+                 draft_pick=DraftPick.Default,
+                 college=College.Default,
+                 country=Country.Default,
+                 height=Height.Default,
+                 weight=Weight.Default
+                 ):
+
+        self.json = _get_json(endpoint=self._endpoint,
+                              params={'LeagueID': league_id,
+                                      'PtMeasureType': self._pt_measure_type,
+                                      'SeasonType': season_type,
+                                      'PlayerOrTeam': player_or_team,
+                                      'PerMode': per_mode,
+                                      'Season': season,
+                                      'PORound': playoff_round,
+                                      'Outcome': outcome,
+                                      'Location': location,
+                                      'Month': month,
+                                      'SeasonSegment': season_segment,
+                                      'DateFrom': date_from,
+                                      'DateTo': date_to,
+                                      'OpponentTeamID': opponent_team_id,
+                                      'VsConference': vs_conference,
+                                      'VsDivision': vs_division,
+                                      'TeamID': team_id,
+                                      'Conference': conference,
+                                      'Division': division,
+                                      'LastNGames': last_n_games,
+                                      'GameScope': game_scope,
+                                      'PlayerExperience': player_experience,
+                                      'PlayerPosition': player_position,
+                                      'StarterBench': starter_bench,
+                                      'DraftYear': draft_year,
+                                      'DraftPick': draft_pick,
+                                      'College': college,
+                                      'Country': country,
+                                      'Height': height,
+                                      'Weight': weight
+                                      })
+
+    def overall(self):
+        return _api_scrape(self.json, 0)
+
+
+class PlayerSpeedDistanceTracking(_PlayerTrackingStats):
+    """
+    Statistics that measure the distance covered and the average speed of all
+    movements (sprinting, jogging, standing, walking, backwards and forwards)
+    by a player while on the court. 
+    """
+    _pt_measure_type=PtMeasureType.SpeedDistance
+
+
 class GameLog:
     _endpoint = 'leaguegamelog'
 

--- a/tests/test_nba_py_league.py
+++ b/tests/test_nba_py_league.py
@@ -1,0 +1,27 @@
+from nba_py import league
+try:
+    # python 2 compatability
+    from future_builtins import filter
+except ImportError:
+    pass
+
+class TestPlayerSpeedDistanceTracking:
+
+    def test_overall(self):
+        speed = league.PlayerSpeedDistanceTracking(date_from='03/05/2016',
+                                                   date_to='03/05/2016')
+        assert speed
+        overall = speed.overall()
+        assert overall
+        iter = filter(lambda d: d['PLAYER_NAME'] == 'Derrick Rose', overall)
+        stats = next(iter)
+        assert stats
+        assert stats['GP'] == 1
+        assert stats['MIN'] == 29.25
+        assert stats['DIST_MILES'] == 2.24
+        assert stats['DIST_FEET'] == 11827.0
+        assert stats['DIST_MILES_OFF'] == 1.29
+        assert stats['DIST_MILES_DEF'] == 0.95
+        assert stats['AVG_SPEED'] == 4.52
+        assert stats['AVG_SPEED_OFF'] == 4.94
+        assert stats['AVG_SPEED_DEF'] == 4.42


### PR DESCRIPTION
Add new endpoint `leaguedashptstats`
Add `_PlayerTrackingStats` in league
Add `PlayerSpeedDistanceTracking` in league.py
Add `test_nba_py_league.py`
Add `PlayerSpeedDistanceTracking` tests

I can add the rest of the `PtMeasureTypes` (ie. the sections from [here](http://stats.nba.com/tracking/#!/player/)) to this PR or make separate new ones...