### PR TITLE
Add requests_cache support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ $ pip install .
 Pandas is nice to have because it'll put the data in an easy to manage object, but it is by no means necessary. All data, if pandas is not installed is returned in a nice json list format with headers!
 - [pandas](http://pandas.pydata.org/) [(Installation Help)](https://github.com/seemethere/nba_py/wiki/Installing-pandas)
 
+Requests-cache is nice to have when you are downloading very large datasets so that subsequent downloads take much less time, but again, it is by no means necessary.
+- [requests-cache](https://github.com/reclosedev/requests-cache)
+
 ## Completed work
 - See the [wiki](https://github.com/seemethere/nba_py/wiki/Completed-Work-Log)
 

--- a/nba_py/__init__.py
+++ b/nba_py/__init__.py
@@ -1,5 +1,5 @@
 from requests import get
-from datetime import datetime
+from datetime import datetime, timedelta
 from nba_py.constants import League
 
 HAS_PANDAS = True
@@ -7,6 +7,12 @@ try:
     from pandas import DataFrame
 except ImportError:
     HAS_PANDAS = False
+
+try:
+    from requests_cache import install_cache
+    install_cache(cache_name='nba_cache', expire_after=timedelta(minutes=10))
+except ImportError:
+    pass
 
 # Constants
 TODAY = datetime.today()


### PR DESCRIPTION
Create a local sqlite database cache in the current working directory when the user has the `requests-cache` library installed so that subsequent API calls happen *much* faster. Currently items are evicted from the cache after 10 minutes but I think it might useful to make this configurable if you think caching is a useful feature.