### PR TITLE
Changes Position to PlayerPosition

### DIFF
--- a/nba_py/shotchart.py
+++ b/nba_py/shotchart.py
@@ -45,7 +45,7 @@ class ShotChart:
                                       'OpponentTeamID' : opponent_team_id,
                                       'VsConference' : vs_conf,
                                       'VsDivision' : vs_div,
-                                      'Position' : position,
+                                      'PlayerPosition' : position,
                                       'GameSegment' : game_segment,
                                       'Period' :  period,
                                       'LastNGames' : last_n_games,


### PR DESCRIPTION
I believe the parameter names for the shot chart endpoint changed slightly. I was getting an error stating "PlayerPosition parameter is required". Modifying this one key seems to have fixed the issue.