### PR TITLE
New feature allows a full list of future games to be viewed.

### DIFF
--- a/examples/example_team.py
+++ b/examples/example_team.py
@@ -24,3 +24,10 @@ except AttributeError:
 print('Spurs stats vs Tyson Chandler (2010-11)')
 print('On court:  {}'.format(float(r_on['FG_PCT'])))
 print('Off court: {}'.format(float(r_off['FG_PCT'])))
+
+# print a list of all dallas games in December
+fs = team.FullSchedule().info()
+list_of_games = fs['lscd'][2]['mscd']['g']  # 0=Oct 1=Nov, 2=Dec...
+for game in list_of_games:
+    if game['v']['tc'] == 'Dallas' or game['h']['tc'] == 'Dallas':
+        print(game['gdte'] + ' ' + game['v']['tc'] + ' ' + game['v']['s'] + ' @ ' + str(game['h']['tc']) + ' ' + game['h']['s'])

--- a/nba_py/__init__.py
+++ b/nba_py/__init__.py
@@ -21,6 +21,7 @@ except ImportError:
 # Constants
 TODAY = datetime.today()
 BASE_URL = 'http://stats.nba.com/stats/{endpoint}'
+SCHEDULE_URL = 'http://data.nba.com/data/10s/v2015/json/mobile_teams/nba/2016/league/00_full_schedule.json'
 HEADERS = {'user-agent': ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) '
                           'AppleWebKit/537.36 (KHTML, like Gecko) '
                           'Chrome/45.0.2454.101 Safari/537.36'),
@@ -81,6 +82,15 @@ def _get_json(endpoint, params, referer='scores'):
     h['referer'] = 'http://stats.nba.com/{ref}/'.format(ref=referer)
     _get = get(BASE_URL.format(endpoint=endpoint), params=params,
                headers=h)
+    # print _get.url
+    _get.raise_for_status()
+    return _get.json()
+
+
+def _get_schedule(referer='schedule'):
+    h = dict(HEADERS)
+    h['referer'] = 'http://stats.nba.com/{ref}/'.format(ref=referer)
+    _get = get(SCHEDULE_URL, headers=h)
     # print _get.url
     _get.raise_for_status()
     return _get.json()

--- a/nba_py/team.py
+++ b/nba_py/team.py
@@ -1,4 +1,4 @@
-from nba_py import _api_scrape, _get_json
+from nba_py import _api_scrape, _get_json, _get_schedule
 from nba_py.constants import *
 
 
@@ -559,3 +559,9 @@ class TeamVsPlayer:
 
     def shot_area_off_court(self):
         return _api_scrape(self.json, 8)
+
+
+class FullSchedule:
+    @staticmethod
+    def info():
+        return _get_schedule()


### PR DESCRIPTION
The json document I pulled in is available at http://data.nba.com/data/10s/v2015/json/mobile_teams/nba/2016/league/00_full_schedule.json

This can be examined further to provide gameids for future games.

An example is also provided.