### PR TITLE
Updated _PlayerDashboard endpoint and Player Profile indexes

### DIFF
--- a/nba_py/player.py
+++ b/nba_py/player.py
@@ -131,7 +131,7 @@ class _PlayerDashboard:
     Attributes:
         :json: Contains the full json dump to play around with
     """
-    _endpoint = ''
+    _endpoint = 'playerdashboardbyyearoveryear'
 
     def __init__(self,
                  player_id,
@@ -677,11 +677,17 @@ class PlayerCareer:
     def college_season_career_totals(self):
         return _api_scrape(self.json, 7)
 
-    def regular_season_rankings(self):
+    def preseason_season_totals(self):
         return _api_scrape(self.json, 8)
 
-    def post_season_rankings(self):
+    def preseason_career_totals(self):
         return _api_scrape(self.json, 9)
+
+    def regular_season_rankings(self):
+        return _api_scrape(self.json, 10)
+
+    def post_season_rankings(self):
+        return _api_scrape(self.json, 11)
 
 
 class PlayerProfile(PlayerCareer):
@@ -700,13 +706,13 @@ class PlayerProfile(PlayerCareer):
     _endpoint = 'playerprofilev2'
 
     def season_highs(self):
-        return _api_scrape(self.json, 10)
+        return _api_scrape(self.json, 12)
 
     def career_highs(self):
-        return _api_scrape(self.json, 11)
+        return _api_scrape(self.json, 13)
 
     def next_game(self):
-        return _api_scrape(self.json, 12)
+        return _api_scrape(self.json, 14)
 
 
 class PlayerGameLogs:


### PR DESCRIPTION
Hello! 

There were a couple of errors I encountered today using the package. For example, the _PlayerDashboard() didn't load and GameProfile().next_game() returned a DataFrame with multiple games from the past. The JSON now contains an array of 14 items, so I'm assuming they added some new information and indexes have to be updated. (Screenshot 1)

The main Player dashboard at nba.com does a request to the endpoint "playerdashboardbyyearoveryear" so I put that in the _Playerdashboard endpoint. 
(Screenshot 2) 

<img width="1282" alt="screen shot 2017-01-22 at 4 40 48 pm" src="https://cloud.githubusercontent.com/assets/6081895/22186910/1dfde3a6-e0c3-11e6-9a20-b08b9b591782.png">
<img width="722" alt="screen shot 2017-01-22 at 4 55 32 pm" src="https://cloud.githubusercontent.com/assets/6081895/22186947/b139e26e-e0c3-11e6-9080-32567972e505.png">
